### PR TITLE
BUG: Add Get{Pixel,Neighborhood}Accessor to CurvilinearArray.

### DIFF
--- a/include/itkCurvilinearArraySpecialCoordinatesImage.h
+++ b/include/itkCurvilinearArraySpecialCoordinatesImage.h
@@ -351,6 +351,22 @@ public:
     FixedArray< TCoordRep, VDimension > & ) const
     {}
 
+  /** Return the Pixel Accessor object */
+  AccessorType GetPixelAccessor(void)
+  { return AccessorType(); }
+
+  /** Return the Pixel Accesor object */
+  const AccessorType GetPixelAccessor(void) const
+  { return AccessorType(); }
+
+  /** Return the NeighborhoodAccessor functor */
+  NeighborhoodAccessorFunctorType GetNeighborhoodAccessor()
+  { return NeighborhoodAccessorFunctorType(); }
+
+  /** Return the NeighborhoodAccessor functor */
+  const NeighborhoodAccessorFunctorType GetNeighborhoodAccessor() const
+  { return NeighborhoodAccessorFunctorType(); }
+
 protected:
   CurvilinearArraySpecialCoordinatesImage()
     {

--- a/test/itkCurvilinearArraySpecialCoordinatesImageTest.cxx
+++ b/test/itkCurvilinearArraySpecialCoordinatesImageTest.cxx
@@ -22,6 +22,7 @@
 #include "itkImageFileWriter.h"
 
 #include "itkResampleImageFilter.h"
+#include "itkWindowedSincInterpolateImageFunction.h"
 
 
 int itkCurvilinearArraySpecialCoordinatesImageTest( int argc, char * argv[] )
@@ -82,6 +83,8 @@ int itkCurvilinearArraySpecialCoordinatesImageTest( int argc, char * argv[] )
   outputOrigin[1] = radiusStart * std::cos( vnl_math::pi / 4.0 );
   outputOrigin[2] = reader->GetOutput()->GetOrigin()[2];
   resampler->SetOutputOrigin( outputOrigin );
+
+  typedef itk::WindowedSincInterpolateImageFunction< SpecialCoordinatesImageType, 3 > WindowedSincInterpolatorType;
 
   typedef itk::ImageFileWriter< ImageType > WriterType;
   WriterType::Pointer writer = WriterType::New();


### PR DESCRIPTION
This allows a windowed-sinc interpolator to be instantiated.