### PR TITLE
BUG: Set PointData name in ToVTKStructuredGridFilter

### DIFF
--- a/include/itkSpecialCoordinatesImageToVTKStructuredGridFilter.hxx
+++ b/include/itkSpecialCoordinatesImageToVTKStructuredGridFilter.hxx
@@ -246,10 +246,12 @@ SpecialCoordinatesImageToVTKStructuredGridFilter< TInputImage >
 
   if( components == 1 )
     {
+    pointDataArray->SetName( "Scalars" );
     this->m_StructuredGrid->GetPointData()->SetScalars( pointDataArray );
     }
   else
     {
+    pointDataArray->SetName( "Vectors" );
     this->m_StructuredGrid->GetPointData()->SetVectors( pointDataArray );
     }
   pointDataArray->Delete();


### PR DESCRIPTION
A named point data array appears to be required / useful for the point
interpolator frame work.