### PR TITLE
ENH: std::deque does not wrap for VS2013 or Ubuntu 17.04.  Switching to std::list

### DIFF
--- a/include/itkSpectra1DImageFilter.h
+++ b/include/itkSpectra1DImageFilter.h
@@ -97,7 +97,7 @@ private:
   typedef std::vector< ScalarType >                  SpectraVectorType;
   typedef typename InputImageType::IndexType         IndexType;
   typedef std::pair< IndexType, SpectraVectorType >  SpectraLineType;
-  typedef std::deque< SpectraLineType >              SpectraLinesContainerType;
+  typedef std::list< SpectraLineType >               SpectraLinesContainerType;
   typedef typename SupportWindowImageType::PixelType SupportWindowType;
   typedef ImageRegionConstIterator< InputImageType > InputImageIteratorType;
   typedef vnl_fft_1d< ScalarType >                   FFT1DType;

--- a/include/itkSpectra1DImageFilter.hxx
+++ b/include/itkSpectra1DImageFilter.hxx
@@ -266,7 +266,7 @@ Spectra1DImageFilter< TInputImage, TSupportWindowImage, TOutputImage >
       outputPixel.SetSize( spectralComponents );
       outputPixel.Fill( NumericTraits< ScalarType >::ZeroValue() );
       typename SpectraVectorType::const_iterator windowIt = perThreadData.LineWindowMap[spectraLinesCount].begin();
-      SpectraLinesContainerType::iterator linesIt = spectraLines.begin();
+      typename SpectraLinesContainerType::iterator linesIt = spectraLines.begin();
       for( size_t line = 0; line < spectraLinesCount; ++line )
         {
         typename SpectraVectorType::const_iterator spectraIt = linesIt->second.begin();

--- a/include/itkSpectra1DImageFilter.hxx
+++ b/include/itkSpectra1DImageFilter.hxx
@@ -224,8 +224,8 @@ Spectra1DImageFilter< TInputImage, TSupportWindowImage, TOutputImage >
         }
       else // subsequent window along a line
         {
-        const IndexValueType desiredFirstLine = supportWindow[0][1];
-        while( spectraLines[0].first[1] < desiredFirstLine )
+        const IndexValueType desiredFirstLine = supportWindow.front()[1];
+        while( spectraLines.front().first[1] < desiredFirstLine )
           {
           spectraLines.pop_front();
           }
@@ -266,15 +266,17 @@ Spectra1DImageFilter< TInputImage, TSupportWindowImage, TOutputImage >
       outputPixel.SetSize( spectralComponents );
       outputPixel.Fill( NumericTraits< ScalarType >::ZeroValue() );
       typename SpectraVectorType::const_iterator windowIt = perThreadData.LineWindowMap[spectraLinesCount].begin();
+      SpectraLinesContainerType::iterator linesIt = spectraLines.begin();
       for( size_t line = 0; line < spectraLinesCount; ++line )
         {
-        typename SpectraVectorType::const_iterator spectraIt = spectraLines[line].second.begin();
+        typename SpectraVectorType::const_iterator spectraIt = linesIt->second.begin();
         for( FFT1DSizeType sample = 0; sample < spectralComponents; ++sample )
           {
           outputPixel[sample] += *windowIt * *spectraIt;
           ++spectraIt;
           }
         ++windowIt;
+        ++linesIt;
         }
       outputIt.Set( outputPixel );
 

--- a/include/itkSpectra1DSupportWindowImageFilter.h
+++ b/include/itkSpectra1DSupportWindowImageFilter.h
@@ -18,7 +18,7 @@
 #ifndef itkSpectra1DSupportWindowImageFilter_h
 #define itkSpectra1DSupportWindowImageFilter_h
 
-#include <deque>
+#include <list>
 
 #include "itkImageToImageFilter.h"
 
@@ -41,7 +41,7 @@ namespace itk
 template< typename TInputImage >
 class Spectra1DSupportWindowImageFilter:
   public ImageToImageFilter< TInputImage,
-                             Image< std::deque< typename TInputImage::IndexType >, TInputImage::ImageDimension > >
+                             Image< std::list< typename TInputImage::IndexType >, TInputImage::ImageDimension > >
 {
 public:
   itkStaticConstMacro( ImageDimension, unsigned int, TInputImage::ImageDimension );
@@ -49,7 +49,7 @@ public:
   typedef TInputImage                              InputImageType;
   typedef typename InputImageType::IndexType       IndexType;
 
-  typedef std::deque< IndexType >                  OutputPixelType;
+  typedef std::list< IndexType >                   OutputPixelType;
   typedef Image< OutputPixelType, ImageDimension > OutputImageType;
 
   typedef unsigned int                             FFT1DSizeType;

--- a/wrapping/itkCurvilinearArraySpecialCoordinatesImage.wrap
+++ b/wrapping/itkCurvilinearArraySpecialCoordinatesImage.wrap
@@ -1,4 +1,4 @@
-itk_wrap_include("deque")
+itk_wrap_include("list")
 itk_wrap_include("complex")
 
 itk_wrap_class("itk::CurvilinearArraySpecialCoordinatesImage" POINTER_WITH_SUPERCLASS)
@@ -91,8 +91,8 @@ itk_wrap_include("itkSpectra1DSupportWindowToMaskImageFilter.h")
 itk_wrap_class("itk::Spectra1DSupportWindowToMaskImageFilter" POINTER_WITH_2_SUPERCLASSES)
   foreach(d ${ITK_WRAP_DIMS})
     foreach(t ${WRAP_ITK_INT})
-      itk_wrap_template("IdequeitkIndex${d}${d}CASCI${ITKM_${t}}${d}"
-        "itk::Image< std::deque< itk::Index< ${d} > >, ${d} >, itk::CurvilinearArraySpecialCoordinatesImage< ${ITKT_${t}}, ${d} >")
+      itk_wrap_template("IlistitkIndex${d}${d}CASCI${ITKM_${t}}${d}"
+        "itk::Image< std::list< itk::Index< ${d} > >, ${d} >, itk::CurvilinearArraySpecialCoordinatesImage< ${ITKT_${t}}, ${d} >")
     endforeach()
   endforeach()
 itk_end_wrap_class()

--- a/wrapping/itkSpectra1DImageFilter.wrap
+++ b/wrapping/itkSpectra1DImageFilter.wrap
@@ -1,11 +1,11 @@
-itk_wrap_include("deque")
+itk_wrap_include("list")
 
 itk_wrap_class("itk::Spectra1DImageFilter" POINTER)
   foreach(d ${ITK_WRAP_DIMS})
     foreach(scalar_t ${WRAP_ITK_SCALAR})
       foreach(real_t ${WRAP_ITK_REAL})
-        itk_wrap_template("${ITKM_I${scalar_t}${d}}IdequeitkIndex${d}${d}${ITKM_VI${real_t}${d}}"
-          "${ITKT_I${scalar_t}${d}}, itk::Image< std::deque< itk::Index< ${d} > >, ${d} >, ${ITKT_VI${real_t}${d}}")
+        itk_wrap_template("${ITKM_I${scalar_t}${d}}IlistitkIndex${d}${d}${ITKM_VI${real_t}${d}}"
+          "${ITKT_I${scalar_t}${d}}, itk::Image< std::list< itk::Index< ${d} > >, ${d} >, ${ITKT_VI${real_t}${d}}")
         endforeach(real_t)
     endforeach(scalar_t)
   endforeach(d)

--- a/wrapping/itkSpectra1DSupportWindowImageFilter.wrap
+++ b/wrapping/itkSpectra1DSupportWindowImageFilter.wrap
@@ -1,16 +1,8 @@
-itk_wrap_include("deque")
-
-set(WRAPPER_AUTO_INCLUDE_HEADERS OFF)
-itk_wrap_class("std::deque" )
-  foreach(d ${ITK_WRAP_DIMS})
-    itk_wrap_template("itkIndex${d}" "itk::Index< ${d} >")
-  endforeach(d)
-itk_end_wrap_class()
-set(WRAPPER_AUTO_INCLUDE_HEADERS ON)
+itk_wrap_include("list")
 
 itk_wrap_class("itk::Image" POINTER)
   foreach(d ${ITK_WRAP_DIMS})
-    itk_wrap_template("dequeitkIndex${d}${d}" "std::deque< itk::Index< ${d} > >, ${d}")
+    itk_wrap_template("listitkIndex${d}${d}" "std::list< itk::Index< ${d} > >, ${d}")
   endforeach(d)
 itk_end_wrap_class()
 

--- a/wrapping/itkSpectra1DSupportWindowToMaskImageFilter.wrap
+++ b/wrapping/itkSpectra1DSupportWindowToMaskImageFilter.wrap
@@ -1,9 +1,9 @@
-itk_wrap_include("deque")
+itk_wrap_include("list")
 
 itk_wrap_class("itk::Spectra1DSupportWindowToMaskImageFilter" POINTER_WITH_2_SUPERCLASSES)
   foreach(d ${ITK_WRAP_DIMS})
     foreach(t ${WRAP_ITK_INT})
-      itk_wrap_template("IdequeitkIndex${d}${d}${ITKM_I${t}${d}}" "itk::Image< std::deque< itk::Index< ${d} > >, ${d} >, ${ITKT_I${t}${d}}")
+      itk_wrap_template("IlistitkIndex${d}${d}${ITKM_I${t}${d}}" "itk::Image< std::list< itk::Index< ${d} > >, ${d} >, ${ITKT_I${t}${d}}")
     endforeach(t)
   endforeach(d)
 itk_end_wrap_class()


### PR DESCRIPTION
When wrapping for python, the use of deque causes errors such as

/home/aylward/src/ITK-Release/Wrapping/Typedefs/itkSpectra1DSupportWindowImageFilter.i:725:
Error: Syntax error in input(3).

The lines throwing the error in the file seem like incomplete/incorrect wrapping specifications for deque:

 std::reverse_iterator< std::_Deque_iterator< itkIndex2, const itk::Index< 2 > &, const itk::Index< 2 > * > > crend() const;
    unsigned long size() const;
    unsigned long max_size() const;
    void resize(unsigned long __new_size);
    void resize(unsigned long __new_size, itkIndex2 const & __x);
    void shrink_to_fit();
    bool empty() const;
    ?unknown? & operator[](unsigned long __n);
    ?unknown? const & operator[](unsigned long __n) const;
    ?unknown? & at(unsigned long __n);
    ?unknown? const & at(unsigned long __n) const;
    ?unknown? & front();
    ?unknown? const & front() const;
    ?unknown? & back();
    ?unknown? const & back() const;
    void push_front(itkIndex2 const & __x);
    void push_back(itkIndex2 const & __x);
    void pop_front();
    void pop_back();
    std::_Deque_iterator< itkIndex2, itkIndex2 &, itkIndex2 * > insert(std::_Deque_iterator< itkIndex2, const itk::Index< 2 > &, const itk::Index< 2 > * > __position, itkIndex2 const & __x);

When using ITK v4.12.0.

This pull request changes instances of deque to list and updates code to maintain speed as much as possible. 
