### PR TITLE
ENH: Limit macOS Python package builds to 2.7 3.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,28 +1,41 @@
 version: 2
 jobs:
   build-and-test:
-    working_directory: ~/ITKUltrasound-build
+    working_directory: /ITKUltrasound-build
     docker:
       - image: insighttoolkit/module-ci:latest
     steps:
       - checkout:
-          path: ~/ITKUltrasound
+          path: /ITKUltrasound
       - run:
-          name: Configure
+          name: Fetch CTest driver script
+          command: |
+            curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITK/dashboard/itk_common.cmake -O
+      - run:
+          name: Configure CTest script
           command: |
             SHASNIP=$(echo $CIRCLE_SHA1 | cut -c1-7)
-            cmake \
-              -DITK_DIR:PATH=/ITK-build \
-              -DBUILD_TESTING:BOOL=ON \
-              -DBUILDNAME:STRING=External-ITKUltrasound-${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}-${SHASNIP} \
-                ~/ITKUltrasound
+            cat > dashboard.cmake << EOF
+            set(CTEST_SITE "CircleCI")
+            set(CTEST_BUILD_NAME "External-ITKUltrasound-${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}-${SHASNIP}")
+            set(CTEST_BUILD_CONFIGURATION "MinSizeRel")
+            set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
+            set(CTEST_BUILD_FLAGS: "-j5")
+            set(CTEST_SOURCE_DIRECTORY /ITKUltrasound)
+            set(CTEST_BINARY_DIRECTORY /ITKUltrasound-build)
+            set(dashboard_model Experimental)
+            set(dashboard_no_clean 1)
+            set(dashboard_cache "
+            ITK_DIR:PATH=/ITK-build
+            BUILD_TESTING:BOOL=ON
+            ")
+            include(\${CTEST_SCRIPT_DIRECTORY}/itk_common.cmake)
+            EOF
       - run:
           name: Build and Test
           no_output_timeout: 1.0h
-          environment:
-            CTEST_BUILD_FLAGS: "-j5"
           command: |
-            ctest -j 2 -VV -D Experimental
+            ctest -j 2 -VV -S dashboard.cmake
   package:
     working_directory: ~/ITKUltrasound
     machine: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ cache:
 script:
 - curl -L https://rawgit.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/macpython-download-cache-and-build-module-wheels.sh -O
 - chmod u+x macpython-download-cache-and-build-module-wheels.sh
-- ./macpython-download-cache-and-build-module-wheels.sh
+- ./macpython-download-cache-and-build-module-wheels.sh 2.7 3.6
 - tar -zcvf dist.tar.gz dist/
 - curl --upload-file dist.tar.gz https://transfer.sh/dist.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ script:
 - chmod u+x macpython-download-cache-and-build-module-wheels.sh
 - ./macpython-download-cache-and-build-module-wheels.sh 2.7 3.6
 - tar -zcvf dist.tar.gz dist/
-- curl --upload-file dist.tar.gz https://transfer.sh/dist.tar.gz
+- curl -F file="@dist.tar.gz" https://filebin.ca/upload.php


### PR DESCRIPTION
Prevent TravisCI timeouts.