### PR TITLE
BUG: Add missing wrapping for itk::Index< std::list >

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
 
 setup(
     name='itk-ultrasound',
-    version='0.2.0',
+    version='0.2.1',
     author='Matthew McCormick',
     author_email='matt.mccormick@kitware.com',
     packages=['itk'],

--- a/wrapping/CMakeLists.txt
+++ b/wrapping/CMakeLists.txt
@@ -1,13 +1,12 @@
-if( ${ITK_WRAP_double} AND NOT ${ITK_WRAP_complex_double})
-        message(WARNING "ITK_WRAP_double is on but ITK_WRAP_complex_double is not. Some filters with double input / outputs depend on complex filters. Set ITK_WRAP_complex_double to on" )
+if(${ITK_WRAP_double} AND NOT ${ITK_WRAP_complex_double})
+  message(WARNING "ITK_WRAP_double is on but ITK_WRAP_complex_double is not. Some filters with double input / outputs depend on complex filters. Set ITK_WRAP_complex_double to on" )
 endif()
 
-if( ${ITK_WRAP_float} AND NOT ${ITK_WRAP_complex_float})
-        message(WARNING "ITK_WRAP_float is on but ITK_WRAP_complex_float is not. Some filters with float input / outputs depend on complex filters. Set ITK_WRAP_complex_float to on" )
+if(${ITK_WRAP_float} AND NOT ${ITK_WRAP_complex_float})
+  message(WARNING "ITK_WRAP_float is on but ITK_WRAP_complex_float is not. Some filters with float input / outputs depend on complex filters. Set ITK_WRAP_complex_float to on" )
 endif()
 
 itk_wrap_module(Ultrasound)
-
 set(WRAPPER_LIBRARY_GROUPS
   itkSpectra1DSupportWindowImageFilter
   itkCurvilinearArraySpecialCoordinatesImage
@@ -15,5 +14,4 @@ set(WRAPPER_LIBRARY_GROUPS
   itkFrequencyDomain1DImageFilter
   )
 itk_auto_load_submodules()
-
 itk_end_wrap_module()

--- a/wrapping/itkSpectra1DSupportWindowImageFilter.wrap
+++ b/wrapping/itkSpectra1DSupportWindowImageFilter.wrap
@@ -1,4 +1,17 @@
 itk_wrap_include("list")
+set(TEMPLATE_LIST_INDEX "")
+foreach(d ${ITK_WRAP_DIMS})
+  set(TEMPLATE_LIST_INDEX "${TEMPLATE_LIST_INDEX}
+%template(listIndex${d}) std::list< itk::Index< ${d} > >;
+")
+  ADD_PYTHON_CONFIG_TEMPLATE("list" "std::list" "listIndex${d}" "itk::Index< ${d} >")
+endforeach()
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/stdlistitkIndex.i.in
+  ${CMAKE_CURRENT_BINARY_DIR}/stdlistitkIndex.i
+  @ONLY
+  )
+set(WRAPPER_SWIG_LIBRARY_FILES ${WRAPPER_SWIG_LIBRARY_FILES}
+  "${CMAKE_CURRENT_BINARY_DIR}/stdlistitkIndex.i")
 
 itk_wrap_class("itk::Image" POINTER)
   foreach(d ${ITK_WRAP_DIMS})

--- a/wrapping/stdlistitkIndex.i.in
+++ b/wrapping/stdlistitkIndex.i.in
@@ -1,0 +1,18 @@
+%{
+// Workaround for undefined SWIGPY_SLICE_ARG with swig 2.0.3 and 2.0.4
+// If removed, fails also with swig 3.0, so this has not been fixed ?
+// Needs to be investigated
+#include <iostream>
+
+#if PY_VERSION_HEX >= 0x03020000
+# define SWIGPY_SLICE_ARG(obj) ((PyObject*) (obj))
+#else
+# define SWIGPY_SLICE_ARG(obj) ((PySliceObject*) (obj))
+#endif
+%}
+
+%include <std_list.i>
+
+namespace std {
+@TEMPLATE_LIST_INDEX@
+}


### PR DESCRIPTION
To address:

  Warning: Unknown parameter 'std::list< itk::Index< 2 > >' in template
  'itk::Image'
  Warning: Unknown parameter 'std::list< itk::Index< 3 > >' in template
  'itk::Image'

Suggested-by: Stephen Aylward <stephen.aylward@kitware.com>