### PR TITLE
COMP: Add missing ObjectFactory header

### DIFF
--- a/include/itkFrequencyDomain1DFilterFunction.h
+++ b/include/itkFrequencyDomain1DFilterFunction.h
@@ -19,6 +19,7 @@
 #define itkFrequencyDomain1DFilterFunction_h
 
 #include "itkObject.h"
+#include "itkObjectFactory.h"
 
 namespace itk
 {


### PR DESCRIPTION
To address:

  /ITKUltrasound/include/itkFrequencyDomain1DFilterFunction.h: In static
  member function 'static itk::FrequencyDomain1DFilterFunction::Pointer
  itk::FrequencyDomain1DFilterFunction::New()':
  /ITK/Modules/Core/Common/include/itkMacro.h:292:24: error: 'ObjectFactory'
  is not a member of 'itk'
       Pointer smartPtr = ::itk::ObjectFactory< x >::Create();