### PR TITLE
COMP: Add missing itkImageRegionIterator.h include

### DIFF
--- a/include/itkBlockMatchingBlockAffineTransformMetricImageFilter.hxx
+++ b/include/itkBlockMatchingBlockAffineTransformMetricImageFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkBlockMatchingBlockAffineTransformMetricImageFilter.h"
 
 #include "itkImageRegionIteratorWithIndex.h"
+#include "itkImageRegionIterator.h"
 
 namespace itk
 {


### PR DESCRIPTION
To address:

  /ITKUltrasound/include/itkBlockMatchingBlockAffineTransformMetricImageFilter.hxx:121:5: error: 'ImageRegionIterator' was not declared in this scope
     ImageRegionIterator< FixedImageType > it( m_TransformedFixedImage, this->m_FixedImageRegion );
     ^~~~~~~~~~~~~~~~~~~
/ITKUltrasound/include/itkBlockMatchingBlockAffineTransformMetricImageFilter.hxx:121:41: error: expected primary-expression before '>' token
     ImageRegionIterator< FixedImageType > it( m_TransformedFixedImage, this->m_FixedImageRegion );
                                         ^
/ITKUltrasound/include/itkBlockMatchingBlockAffineTransformMetricImageFilter.hxx:123:10: error: 'it' was not declared in this scope
     for( it.GoToBegin(); !it.IsAtEnd(); ++it )
          ^~