### PR TITLE
COMP: enable building even with ITK_LEGACY_REMOVE turned ON

### DIFF
--- a/include/itkFFTWComplexToComplex1DFFTImageFilter.hxx
+++ b/include/itkFFTWComplexToComplex1DFFTImageFilter.hxx
@@ -74,7 +74,7 @@ FFTWComplexToComplex1DFFTImageFilter< TInputImage, TOutputImage >
     }
   if( ! this->m_PlanComputed )
     {
-    const int threads = this->GetNumberOfThreads();
+    const int threads = this->GetNumberOfWorkUnits();
     m_PlanArray.resize( threads );
     m_InputBufferArray.resize( threads );
     m_OutputBufferArray.resize( threads );

--- a/include/itkFFTWForward1DFFTImageFilter.hxx
+++ b/include/itkFFTWForward1DFFTImageFilter.hxx
@@ -74,7 +74,7 @@ FFTWForward1DFFTImageFilter< TInputImage, TOutputImage >
     }
   if( ! this->m_PlanComputed )
     {
-    const int threads = this->GetNumberOfThreads();
+    const int threads = this->GetNumberOfWorkUnits();
     m_PlanArray.resize( threads );
     m_InputBufferArray.resize( threads );
     m_OutputBufferArray.resize( threads );

--- a/include/itkFFTWInverse1DFFTImageFilter.hxx
+++ b/include/itkFFTWInverse1DFFTImageFilter.hxx
@@ -73,7 +73,7 @@ FFTWInverse1DFFTImageFilter< TInputImage, TOutputImage >
     }
   if( ! this->m_PlanComputed )
     {
-    const int threads = this->GetNumberOfThreads();
+    const int threads = this->GetNumberOfWorkUnits();
     m_PlanArray.resize( threads );
     m_InputBufferArray.resize( threads );
     m_OutputBufferArray.resize( threads );


### PR DESCRIPTION
Todo: rebuild and merge after the next ITK 5 tag and the Python CI images have been updated to support `GetNumberOfWorkUnits`.