### PR TITLE
BUG: Only prepare itk-ultrasound wheels for PyPI upload

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -365,10 +365,10 @@ jobs:
       run: |
         ls -R
         for d in */; do
-          mv ${d}/*.whl .
+          mv ${d}/itk_ultrasound*.whl .
         done
         mkdir dist
-        mv *.whl dist/
+        mv itk_ultrasound*.whl dist/
         ls dist
 
     - name: Publish 🐍 Python 📦 package to PyPI


### PR DESCRIPTION
Avoid ITK module dependency wheels.