### PR TITLE
ENH: Add `itkAnalyticSignalImageFilter` and `itkRegionFromReferenceImageFilter` wrappings

### DIFF
--- a/wrapping/CMakeLists.txt
+++ b/wrapping/CMakeLists.txt
@@ -14,6 +14,8 @@ set(WRAPPER_LIBRARY_GROUPS
   itkFrequencyDomain1DImageFilter
   itkForward1DFFTImageFilter
   itkInverse1DFFTImageFilter
+  itkRegionFromReferenceImageFilter
+  itkAnalyticSignalImageFilter
   itkBModeImageFilter
   )
 itk_auto_load_submodules()

--- a/wrapping/itkAnalyticSignalImageFilter.wrap
+++ b/wrapping/itkAnalyticSignalImageFilter.wrap
@@ -1,0 +1,8 @@
+itk_wrap_class("itk::AnalyticSignalImageFilter" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(rt ${WRAP_ITK_REAL})
+      itk_wrap_template("I${ITKM_${rt}}${d}I${ITKM_C${rt}}${d}"
+        "itk::Image<${ITKT_${rt}}, ${d}>, itk::Image<${ITKT_C${rt}}, ${d}>")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()

--- a/wrapping/itkRegionFromReferenceImageFilter.wrap
+++ b/wrapping/itkRegionFromReferenceImageFilter.wrap
@@ -1,0 +1,3 @@
+itk_wrap_class("itk::RegionFromReferenceImageFilter" POINTER)
+  itk_wrap_image_filter("${WRAP_ITK_REAL}" 2)
+itk_end_wrap_class()


### PR DESCRIPTION
Exposes `itkAnalyticSignalImageFilter` and `itkRegionFromReferenceImageFilter` for illustration in example notebook.