### PR TITLE
STYLE: Add a semicolon to the end of each macro invocation.

### DIFF
--- a/include/itkButterworthBandpass1DFilterFunction.h
+++ b/include/itkButterworthBandpass1DFilterFunction.h
@@ -54,15 +54,17 @@ public:
     return x * y;
   };
 
-  itkSetMacro(UpperFrequency, double) itkGetMacro(UpperFrequency, double)
+  itkSetMacro(UpperFrequency, double);
+  itkGetMacro(UpperFrequency, double);
 
-    itkSetMacro(LowerFrequency, double) itkGetMacro(LowerFrequency, double)
+  itkSetMacro(LowerFrequency, double);
+  itkGetMacro(LowerFrequency, double);
 
-      itkSetMacro(Order, int) itkGetMacro(Order, int)
+  itkSetMacro(Order, int);
+  itkGetMacro(Order, int);
 
 
-        protected
-    :
+protected:
 
     ButterworthBandpass1DFilterFunction()
   {


### PR DESCRIPTION
Add `;` to the end of statements of the form `itkGetMacro(...)` and `itkSetMacro(...)`.