### PR TITLE
BUG: Fix linux python CI runner cleanup step

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -151,14 +151,9 @@ jobs:
       run: |
         # Workaround for https://github.com/actions/virtual-environments/issues/709
         df -h
-        sudo apt-get remove -y '^ghc-8.*'
-        sudo apt-get remove -y '^dotnet-.*'
-        sudo apt-get remove -y '^llvm-.*'
-        sudo apt-get remove -y 'php.*'
         sudo apt-get autoremove -y
         sudo apt-get clean
         sudo rm -rf "/usr/local/share/boost"
-        sudo rm -rf /usr/share/dotnet/
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
         df -h
 


### PR DESCRIPTION
Linux Python CI includes a cleanup step to work around disk space constraints. It appears that several of these commands are no longer valid and must be removed.

See [ITKVkFFTBackend](https://github.com/InsightSoftwareConsortium/ITKVkFFTBackend/blob/master/.github/workflows/build-test-package.yml) for another example of an external module where cleanup steps have been reduced and CI is passing.

Fixes Linux Python CI failures in [https://github.com/KitwareMedical/ITKUltrasound/pull/162](https://github.com/KitwareMedical/ITKUltrasound/pull/162). Notebook CI failures are addressed in [https://github.com/KitwareMedical/ITKUltrasound/pull/165](https://github.com/KitwareMedical/ITKUltrasound/pull/165).