### PR TITLE
BUG: Fix Jupyter Notebook CI Python Version

### DIFF
--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -15,6 +15,8 @@ jobs:
 
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
     - name: Install build dependencies
       run: |
           python -m pip install -r ./.binder/requirements.txt


### PR DESCRIPTION
Fixes Jupyter Notebook dependency test failure in [https://github.com/KitwareMedical/ITKUltrasound/pull/162](https://github.com/KitwareMedical/ITKUltrasound/pull/162) where Python 3.10 is installed by default but itk-ultrasound packages are only available for 3.6 - 3.9 on PyPi (for now).

Linux Python CI failures are addressed in [https://github.com/KitwareMedical/ITKUltrasound/pull/164](https://github.com/KitwareMedical/ITKUltrasound/pull/164).