### PR TITLE
Quote sys.executable path in PlotPowerSpectra because of spaces in name

### DIFF
--- a/examples/PlotPowerSpectra.ipynb
+++ b/examples/PlotPowerSpectra.ipynb
@@ -18,7 +18,7 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "!{sys.executable} -m pip install itk matplotlib scipy numpy"
+    "!\"{sys.executable}\" -m pip install itk matplotlib scipy numpy"
    ]
   },
   {


### PR DESCRIPTION
Without it, t the following error is produced on Windows:

'c:\program' is not recognized as an internal or external command,
operable program or batch file.