### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkAnalyticSignalImageFilter.hxx
+++ b/include/itkAnalyticSignalImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkAnalyticSignalImageFilter_hxx
 #define itkAnalyticSignalImageFilter_hxx
 
-#include "itkAnalyticSignalImageFilter.h"
 
 #include "itkVnlForward1DFFTImageFilter.h"
 #include "itkVnlComplexToComplex1DFFTImageFilter.h"

--- a/include/itkBModeImageFilter.hxx
+++ b/include/itkBModeImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBModeImageFilter_hxx
 #define itkBModeImageFilter_hxx
 
-#include "itkBModeImageFilter.h"
 
 #include "itkMetaDataDictionary.h"
 

--- a/include/itkBlockMatchingBayesianRegularizationDisplacementCalculator.hxx
+++ b/include/itkBlockMatchingBayesianRegularizationDisplacementCalculator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingBayesianRegularizationDisplacementCalculator_hxx
 #define itkBlockMatchingBayesianRegularizationDisplacementCalculator_hxx
 
-#include "itkBlockMatchingBayesianRegularizationDisplacementCalculator.h"
 #include "itkBlockMatchingMaximumPixelDisplacementCalculator.h"
 
 #include "itkNeighborhoodAlgorithm.h"

--- a/include/itkBlockMatchingBlockAffineTransformMetricImageFilter.hxx
+++ b/include/itkBlockMatchingBlockAffineTransformMetricImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingBlockAffineTransformMetricImageFilter_hxx
 #define itkBlockMatchingBlockAffineTransformMetricImageFilter_hxx
 
-#include "itkBlockMatchingBlockAffineTransformMetricImageFilter.h"
 
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkImageRegionIterator.h"

--- a/include/itkBlockMatchingCosineInterpolationDisplacementCalculator.hxx
+++ b/include/itkBlockMatchingCosineInterpolationDisplacementCalculator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingCosineInterpolationDisplacementCalculator_hxx
 #define itkBlockMatchingCosineInterpolationDisplacementCalculator_hxx
 
-#include "itkBlockMatchingCosineInterpolationDisplacementCalculator.h"
 
 #include "itkImageRegionConstIteratorWithIndex.h"
 

--- a/include/itkBlockMatchingDisplacementPipeline.hxx
+++ b/include/itkBlockMatchingDisplacementPipeline.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingDisplacementPipeline_hxx
 #define itkBlockMatchingDisplacementPipeline_hxx
 
-#include "itkBlockMatchingDisplacementPipeline.h"
 
 namespace itk
 {

--- a/include/itkBlockMatchingImageRegistrationMethod.hxx
+++ b/include/itkBlockMatchingImageRegistrationMethod.hxx
@@ -23,7 +23,6 @@
 #include "itkProgressReporter.h"
 
 #include "itkBlockMatchingMaximumPixelDisplacementCalculator.h"
-#include "itkBlockMatchingImageRegistrationMethod.h"
 
 
 namespace itk

--- a/include/itkBlockMatchingImageToImageMetricMetricImageFilter.hxx
+++ b/include/itkBlockMatchingImageToImageMetricMetricImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingImageToImageMetricMetricImageFilter_hxx
 #define itkBlockMatchingImageToImageMetricMetricImageFilter_hxx
 
-#include "itkBlockMatchingImageToImageMetricMetricImageFilter.h"
 
 namespace itk
 {

--- a/include/itkBlockMatchingMaximumPixelDisplacementCalculator.hxx
+++ b/include/itkBlockMatchingMaximumPixelDisplacementCalculator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingMaximumPixelDisplacementCalculator_hxx
 #define itkBlockMatchingMaximumPixelDisplacementCalculator_hxx
 
-#include "itkBlockMatchingMaximumPixelDisplacementCalculator.h"
 
 #include "itkImageRegionConstIteratorWithIndex.h"
 

--- a/include/itkBlockMatchingMetricImageFilter.hxx
+++ b/include/itkBlockMatchingMetricImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingMetricImageFilter_hxx
 #define itkBlockMatchingMetricImageFilter_hxx
 
-#include "itkBlockMatchingMetricImageFilter.h"
 
 namespace itk
 {

--- a/include/itkBlockMatchingMetricImageToDisplacementCalculator.hxx
+++ b/include/itkBlockMatchingMetricImageToDisplacementCalculator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingMetricImageToDisplacementCalculator_hxx
 #define itkBlockMatchingMetricImageToDisplacementCalculator_hxx
 
-#include "itkBlockMatchingMetricImageToDisplacementCalculator.h"
 
 #include "itkImageRegionConstIterator.h"
 #include "itkImageRegionIterator.h"

--- a/include/itkBlockMatchingMultiResolutionFixedSearchRegionImageSource.hxx
+++ b/include/itkBlockMatchingMultiResolutionFixedSearchRegionImageSource.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingMultiResolutionFixedSearchRegionImageSource_hxx
 #define itkBlockMatchingMultiResolutionFixedSearchRegionImageSource_hxx
 
-#include "itkBlockMatchingMultiResolutionFixedSearchRegionImageSource.h"
 
 #include "itkImageRegionConstIterator.h"
 #include "itkImageRegionIteratorWithIndex.h"

--- a/include/itkBlockMatchingMultiResolutionImageRegistrationMethod.hxx
+++ b/include/itkBlockMatchingMultiResolutionImageRegistrationMethod.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingMultiResolutionImageRegistrationMethod_hxx
 #define itkBlockMatchingMultiResolutionImageRegistrationMethod_hxx
 
-#include "itkBlockMatchingMultiResolutionImageRegistrationMethod.h"
 
 #include "itkRecursiveMultiResolutionPyramidImageFilter.h"
 

--- a/include/itkBlockMatchingMultiResolutionIterationCommand.hxx
+++ b/include/itkBlockMatchingMultiResolutionIterationCommand.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingMultiResolutionIterationCommand_hxx
 #define itkBlockMatchingMultiResolutionIterationCommand_hxx
 
-#include "itkBlockMatchingMultiResolutionIterationCommand.h"
 
 namespace itk
 {

--- a/include/itkBlockMatchingMultiResolutionIterationDisplacementCalculatorCommand.hxx
+++ b/include/itkBlockMatchingMultiResolutionIterationDisplacementCalculatorCommand.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingMultiResolutionIterationDisplacementCalculatorCommand_hxx
 #define itkBlockMatchingMultiResolutionIterationDisplacementCalculatorCommand_hxx
 
-#include "itkBlockMatchingMultiResolutionIterationDisplacementCalculatorCommand.h"
 
 namespace itk
 {

--- a/include/itkBlockMatchingMultiResolutionIterationObserver.hxx
+++ b/include/itkBlockMatchingMultiResolutionIterationObserver.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingMultiResolutionIterationObserver_hxx
 #define itkBlockMatchingMultiResolutionIterationObserver_hxx
 
-#include "itkBlockMatchingMultiResolutionIterationObserver.h"
 
 #include <iostream>
 #include <sstream>

--- a/include/itkBlockMatchingMultiResolutionMinMaxSearchRegionImageSource.hxx
+++ b/include/itkBlockMatchingMultiResolutionMinMaxSearchRegionImageSource.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingMultiResolutionMinMaxSearchRegionImageSource_hxx
 #define itkBlockMatchingMultiResolutionMinMaxSearchRegionImageSource_hxx
 
-#include "itkBlockMatchingMultiResolutionMinMaxSearchRegionImageSource.h"
 
 #include "itkImageRegionConstIterator.h"
 #include "itkImageRegionIteratorWithIndex.h"

--- a/include/itkBlockMatchingMultiResolutionSearchRegionImageSource.hxx
+++ b/include/itkBlockMatchingMultiResolutionSearchRegionImageSource.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingMultiResolutionSearchRegionImageSource_hxx
 #define itkBlockMatchingMultiResolutionSearchRegionImageSource_hxx
 
-#include "itkBlockMatchingMultiResolutionSearchRegionImageSource.h"
 #include "itkNearestNeighborExtrapolateImageFunction.h"
 
 namespace itk

--- a/include/itkBlockMatchingMultiResolutionSearchRegionWriterCommand.hxx
+++ b/include/itkBlockMatchingMultiResolutionSearchRegionWriterCommand.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingMultiResolutionSearchRegionWriterCommand_hxx
 #define itkBlockMatchingMultiResolutionSearchRegionWriterCommand_hxx
 
-#include "itkBlockMatchingMultiResolutionSearchRegionWriterCommand.h"
 
 #include <fstream>
 #include <iostream>

--- a/include/itkBlockMatchingMultiResolutionSimilarityFunctionSearchRegionImageSource.hxx
+++ b/include/itkBlockMatchingMultiResolutionSimilarityFunctionSearchRegionImageSource.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingMultiResolutionSimilarityFunctionSearchRegionImageSource_hxx
 #define itkBlockMatchingMultiResolutionSimilarityFunctionSearchRegionImageSource_hxx
 
-#include "itkBlockMatchingMultiResolutionSimilarityFunctionSearchRegionImageSource.h"
 #include "itkBlockMatchingMaximumPixelDisplacementCalculator.h"
 
 #include "itkImageConstIteratorWithIndex.h"

--- a/include/itkBlockMatchingMultiResolutionThresholdBoundingBoxSearchRegionImageSource.hxx
+++ b/include/itkBlockMatchingMultiResolutionThresholdBoundingBoxSearchRegionImageSource.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingMultiResolutionThresholdBoundingBoxSearchRegionImageSource_hxx
 #define itkBlockMatchingMultiResolutionThresholdBoundingBoxSearchRegionImageSource_hxx
 
-#include "itkBlockMatchingMultiResolutionThresholdBoundingBoxSearchRegionImageSource.h"
 
 #include "itkImageLinearConstIteratorWithIndex.h"
 #include "itkImageRegionConstIterator.h"

--- a/include/itkBlockMatchingNormalizedCrossCorrelationFFTMetricImageFilter.hxx
+++ b/include/itkBlockMatchingNormalizedCrossCorrelationFFTMetricImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingNormalizedCrossCorrelationFFTMetricImageFilter_hxx
 #define itkBlockMatchingNormalizedCrossCorrelationFFTMetricImageFilter_hxx
 
-#include "itkBlockMatchingNormalizedCrossCorrelationFFTMetricImageFilter.h"
 
 #include "itkImageRegionConstIterator.h"
 #include "itkImageRegionIterator.h"

--- a/include/itkBlockMatchingNormalizedCrossCorrelationMetricImageFilter.hxx
+++ b/include/itkBlockMatchingNormalizedCrossCorrelationMetricImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingNormalizedCrossCorrelationMetricImageFilter_hxx
 #define itkBlockMatchingNormalizedCrossCorrelationMetricImageFilter_hxx
 
-#include "itkBlockMatchingNormalizedCrossCorrelationMetricImageFilter.h"
 
 #include "itkConstNeighborhoodIterator.h"
 #include "itkImageKernelOperator.h"

--- a/include/itkBlockMatchingNormalizedCrossCorrelationNeighborhoodIteratorMetricImageFilter.hxx
+++ b/include/itkBlockMatchingNormalizedCrossCorrelationNeighborhoodIteratorMetricImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingNormalizedCrossCorrelationNeighborhoodIteratorMetricImageFilter_hxx
 #define itkBlockMatchingNormalizedCrossCorrelationNeighborhoodIteratorMetricImageFilter_hxx
 
-#include "itkBlockMatchingNormalizedCrossCorrelationNeighborhoodIteratorMetricImageFilter.h"
 
 #include "itkConstantBoundaryCondition.h"
 #include "itkConstNeighborhoodIterator.h"

--- a/include/itkBlockMatchingOptimizingInterpolationDisplacementCalculator.hxx
+++ b/include/itkBlockMatchingOptimizingInterpolationDisplacementCalculator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingOptimizingInterpolationDisplacementCalculator_hxx
 #define itkBlockMatchingOptimizingInterpolationDisplacementCalculator_hxx
 
-#include "itkBlockMatchingOptimizingInterpolationDisplacementCalculator.h"
 
 #include "itkImageRegionConstIteratorWithIndex.h"
 

--- a/include/itkBlockMatchingParabolicInterpolationDisplacementCalculator.hxx
+++ b/include/itkBlockMatchingParabolicInterpolationDisplacementCalculator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingParabolicInterpolationDisplacementCalculator_hxx
 #define itkBlockMatchingParabolicInterpolationDisplacementCalculator_hxx
 
-#include "itkBlockMatchingParabolicInterpolationDisplacementCalculator.h"
 
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkImageRegionConstIterator.h"

--- a/include/itkBlockMatchingSearchRegionImageInitializer.hxx
+++ b/include/itkBlockMatchingSearchRegionImageInitializer.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingSearchRegionImageInitializer_hxx
 #define itkBlockMatchingSearchRegionImageInitializer_hxx
 
-#include "itkBlockMatchingSearchRegionImageInitializer.h"
 
 #include "itkImageRegionIteratorWithIndex.h"
 

--- a/include/itkBlockMatchingStrainWindowBlockAffineTransformCommand.hxx
+++ b/include/itkBlockMatchingStrainWindowBlockAffineTransformCommand.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingStrainWindowBlockAffineTransformCommand_hxx
 #define itkBlockMatchingStrainWindowBlockAffineTransformCommand_hxx
 
-#include "itkBlockMatchingStrainWindowBlockAffineTransformCommand.h"
 
 namespace itk
 {

--- a/include/itkBlockMatchingStrainWindowDisplacementCalculator.hxx
+++ b/include/itkBlockMatchingStrainWindowDisplacementCalculator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBlockMatchingStrainWindowDisplacementCalculator_hxx
 #define itkBlockMatchingStrainWindowDisplacementCalculator_hxx
 
-#include "itkBlockMatchingStrainWindowDisplacementCalculator.h"
 #include "itkBlockMatchingMaximumPixelDisplacementCalculator.h"
 
 #include "itkStrainImageFilter.h"

--- a/include/itkBoxSigmaSqrtNMinusOneImageFilter.hxx
+++ b/include/itkBoxSigmaSqrtNMinusOneImageFilter.hxx
@@ -19,7 +19,6 @@
 #define itkBoxSigmaSqrtNMinusOneImageFilter_hxx
 
 #include "itkImage.h"
-#include "itkBoxSigmaSqrtNMinusOneImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkOffset.h"
 #include "itkProgressAccumulator.h"

--- a/include/itkComplexToComplex1DFFTImageFilter.hxx
+++ b/include/itkComplexToComplex1DFFTImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkComplexToComplex1DFFTImageFilter_hxx
 #define itkComplexToComplex1DFFTImageFilter_hxx
 
-#include "itkComplexToComplex1DFFTImageFilter.h"
 
 #include "itkVnlComplexToComplex1DFFTImageFilter.h"
 

--- a/include/itkCurvilinearArraySpecialCoordinatesImage.hxx
+++ b/include/itkCurvilinearArraySpecialCoordinatesImage.hxx
@@ -27,7 +27,6 @@
  *=========================================================================*/
 #ifndef itkCurvilinearArraySpecialCoordinatesImage_hxx
 #define itkCurvilinearArraySpecialCoordinatesImage_hxx
-#include "itkCurvilinearArraySpecialCoordinatesImage.h"
 
 #include <complex>
 

--- a/include/itkFFTWComplexToComplex1DFFTImageFilter.hxx
+++ b/include/itkFFTWComplexToComplex1DFFTImageFilter.hxx
@@ -19,7 +19,6 @@
 #define itkFFTWComplexToComplex1DFFTImageFilter_hxx
 
 #include "itkComplexToComplex1DFFTImageFilter.hxx"
-#include "itkFFTWComplexToComplex1DFFTImageFilter.h"
 
 #include "itkFFTWCommonExtended.h"
 #include "itkIndent.h"

--- a/include/itkFFTWForward1DFFTImageFilter.hxx
+++ b/include/itkFFTWForward1DFFTImageFilter.hxx
@@ -19,7 +19,6 @@
 #define itkFFTWForward1DFFTImageFilter_hxx
 
 #include "itkForward1DFFTImageFilter.hxx"
-#include "itkFFTWForward1DFFTImageFilter.h"
 
 #include "itkFFTWCommonExtended.h"
 #include "itkIndent.h"

--- a/include/itkFFTWInverse1DFFTImageFilter.hxx
+++ b/include/itkFFTWInverse1DFFTImageFilter.hxx
@@ -19,7 +19,6 @@
 #define itkFFTWInverse1DFFTImageFilter_hxx
 
 #include "itkInverse1DFFTImageFilter.hxx"
-#include "itkFFTWInverse1DFFTImageFilter.h"
 
 #include "itkFFTWCommonExtended.h"
 #include "itkIndent.h"

--- a/include/itkForward1DFFTImageFilter.hxx
+++ b/include/itkForward1DFFTImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkForward1DFFTImageFilter_hxx
 #define itkForward1DFFTImageFilter_hxx
 
-#include "itkForward1DFFTImageFilter.h"
 
 #include "itkVnlForward1DFFTImageFilter.h"
 

--- a/include/itkFrequencyDomain1DImageFilter.hxx
+++ b/include/itkFrequencyDomain1DImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkFrequencyDomain1DImageFilter_hxx
 #define itkFrequencyDomain1DImageFilter_hxx
 
-#include "itkFrequencyDomain1DImageFilter.h"
 
 #include "itkImageLinearConstIteratorWithIndex.h"
 #include "itkImageLinearIteratorWithIndex.h"

--- a/include/itkInverse1DFFTImageFilter.hxx
+++ b/include/itkInverse1DFFTImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkInverse1DFFTImageFilter_hxx
 #define itkInverse1DFFTImageFilter_hxx
 
-#include "itkInverse1DFFTImageFilter.h"
 
 #include "itkVnlInverse1DFFTImageFilter.h"
 

--- a/include/itkLinearLeastSquaresGradientImageFilter.hxx
+++ b/include/itkLinearLeastSquaresGradientImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkLinearLeastSquaresGradientImageFilter_hxx
 #define itkLinearLeastSquaresGradientImageFilter_hxx
 
-#include "itkLinearLeastSquaresGradientImageFilter.h"
 
 #include "itkConstNeighborhoodIterator.h"
 #include "itkImageRegionIterator.h"

--- a/include/itkRegionFromReferenceImageFilter.hxx
+++ b/include/itkRegionFromReferenceImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkRegionFromReferenceImageFilter_hxx
 #define itkRegionFromReferenceImageFilter_hxx
 
-#include "itkRegionFromReferenceImageFilter.h"
 
 namespace itk
 {

--- a/include/itkSliceSeriesSpecialCoordinatesImage.hxx
+++ b/include/itkSliceSeriesSpecialCoordinatesImage.hxx
@@ -27,7 +27,6 @@
  *=========================================================================*/
 #ifndef itkSliceSeriesSpecialCoordinatesImage_hxx
 #define itkSliceSeriesSpecialCoordinatesImage_hxx
-#include "itkSliceSeriesSpecialCoordinatesImage.h"
 
 namespace itk
 {

--- a/include/itkSpecialCoordinatesImageToVTKStructuredGridFilter.hxx
+++ b/include/itkSpecialCoordinatesImageToVTKStructuredGridFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkSpecialCoordinatesImageToVTKStructuredGridFilter_hxx
 #define itkSpecialCoordinatesImageToVTKStructuredGridFilter_hxx
 
-#include "itkSpecialCoordinatesImageToVTKStructuredGridFilter.h"
 
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkPixelTraits.h"

--- a/include/itkSpeckleReducingAnisotropicDiffusionFunction.hxx
+++ b/include/itkSpeckleReducingAnisotropicDiffusionFunction.hxx
@@ -18,7 +18,6 @@
 #ifndef itkSpeckleReducingAnisotropicDiffusionFunction_hxx
 #define itkSpeckleReducingAnisotropicDiffusionFunction_hxx
 
-#include "itkSpeckleReducingAnisotropicDiffusionFunction.h"
 
 #include <cmath>
 #include "itkMath.h"

--- a/include/itkSpectra1DImageFilter.hxx
+++ b/include/itkSpectra1DImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkSpectra1DImageFilter_hxx
 #define itkSpectra1DImageFilter_hxx
 
-#include "itkSpectra1DImageFilter.h"
 
 #include "itkImageLinearConstIteratorWithIndex.h"
 #include "itkImageLinearIteratorWithIndex.h"

--- a/include/itkSpectra1DSupportWindowImageFilter.hxx
+++ b/include/itkSpectra1DSupportWindowImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkSpectra1DSupportWindowImageFilter_hxx
 #define itkSpectra1DSupportWindowImageFilter_hxx
 
-#include "itkSpectra1DSupportWindowImageFilter.h"
 #include "itkImageRegionIterator.h"
 #include "itkImageLinearConstIteratorWithIndex.h"
 #include "itkMetaDataObject.h"

--- a/include/itkSpectra1DSupportWindowToMaskImageFilter.hxx
+++ b/include/itkSpectra1DSupportWindowToMaskImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkSpectra1DSupportWindowToMaskImageFilter_hxx
 #define itkSpectra1DSupportWindowToMaskImageFilter_hxx
 
-#include "itkSpectra1DSupportWindowToMaskImageFilter.h"
 #include "itkSpectra1DSupportWindowImageFilter.h"
 #include "itkImageRegionIterator.h"
 #include "itkImageRegionConstIteratorWithIndex.h"

--- a/include/itkTimeGainCompensationImageFilter.hxx
+++ b/include/itkTimeGainCompensationImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkTimeGainCompensationImageFilter_hxx
 #define itkTimeGainCompensationImageFilter_hxx
 
-#include "itkTimeGainCompensationImageFilter.h"
 
 #include "itkImageScanlineIterator.h"
 #include "itkImageScanlineConstIterator.h"

--- a/include/itkUltrasoundImageFileReader.hxx
+++ b/include/itkUltrasoundImageFileReader.hxx
@@ -18,7 +18,6 @@
 #ifndef itkUltrasoundImageFileReader_hxx
 #define itkUltrasoundImageFileReader_hxx
 
-#include "itkUltrasoundImageFileReader.h"
 
 #include "itkMetaDataDictionary.h"
 #include "itkMetaDataObject.h"

--- a/include/itkVnlComplexToComplex1DFFTImageFilter.hxx
+++ b/include/itkVnlComplexToComplex1DFFTImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkVnlComplexToComplex1DFFTImageFilter_hxx
 #define itkVnlComplexToComplex1DFFTImageFilter_hxx
 
-#include "itkVnlComplexToComplex1DFFTImageFilter.h"
 
 #include "itkComplexToComplex1DFFTImageFilter.hxx"
 #include "itkImageLinearConstIteratorWithIndex.h"

--- a/include/itkVnlForward1DFFTImageFilter.hxx
+++ b/include/itkVnlForward1DFFTImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkVnlForward1DFFTImageFilter_hxx
 #define itkVnlForward1DFFTImageFilter_hxx
 
-#include "itkVnlForward1DFFTImageFilter.h"
 
 #include "itkForward1DFFTImageFilter.hxx"
 #include "itkImageLinearConstIteratorWithIndex.h"

--- a/include/itkVnlInverse1DFFTImageFilter.hxx
+++ b/include/itkVnlInverse1DFFTImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkVnlInverse1DFFTImageFilter_hxx
 #define itkVnlInverse1DFFTImageFilter_hxx
 
-#include "itkVnlInverse1DFFTImageFilter.h"
 
 #include "itkInverse1DFFTImageFilter.hxx"
 #include "itkImageLinearConstIteratorWithIndex.h"


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

