### PR TITLE
ENH: Update the minimum required version of CMake to match ITK 5.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(Ultrasound)
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.16.3)
 
 set(Ultrasound_LIBRARIES Ultrasound)
 


### PR DESCRIPTION
Otherwise we run into:
```text
cmake_minimum_required of 3.10.2 is not enough.
CMake Warning at C:/Dev/ITK-git/CMake/ITKModuleExternal.cmake:12 (message):
  cmake_minimum_required must be at least 3.16.3
Call Stack (most recent call first):
  CMakeLists.txt:105 (include)


This is needed to allow proper setting of CMAKE_MSVC_RUNTIME_LIBRARY.
Do not be surprised if you run into link errors of the style:
  error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_Static' doesn't match value 'MDd_Dynamic' in module.obj
```