### PR TITLE
BUG: Make ITKVideo modules test dependencies

### DIFF
--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -15,8 +15,6 @@ itk_module(Ultrasound
     ITKIOImageBase
     ITKTransform
     ITKRegistrationCommon
-    ITKVideoCore
-    ITKVideoIO
     ${_fft_depends}
   COMPILE_DEPENDS
     SplitComponents
@@ -27,6 +25,9 @@ itk_module(Ultrasound
     ITKHDF5
     ITKTestKernel
     ITKImageSources
+  TEST_DEPENDS
+    ITKVideoCore
+    ITKVideoIO
   EXCLUDE_FROM_DEFAULT
   ENABLE_SHARED
   DESCRIPTION

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from skbuild import setup
 
 setup(
     name='itk-ultrasound',
-    version='0.5.1',
+    version='0.5.2',
     author='Matthew McCormick',
     author_email='matt.mccormick@kitware.com',
     packages=['itk'],


### PR DESCRIPTION
Moves ITKVideoCore and ITKVideoIO to TEST_DEPENDS rather than DEPENDS in
order to resolve Python module distribution dependency issue. Closes #175.