### PR TITLE
BUG: Set module wrapping order

### DIFF
--- a/wrapping/CMakeLists.txt
+++ b/wrapping/CMakeLists.txt
@@ -7,14 +7,14 @@ if(${ITK_WRAP_float} AND NOT ${ITK_WRAP_complex_float})
 endif()
 
 itk_wrap_module(Ultrasound)
-set(WRAPPER_LIBRARY_GROUPS
+set(WRAPPER_SUBMODULE_ORDER
+  itkCurvilinearArraySpecialCoordinatesImage
   itkAttenuationImageFilter
   itkBlockMatchingMetricImageFilter
   itkBlockMatchingNormalizedCrossCorrelationMetricImageFilter
   itkBlockMatchingNormalizedCrossCorrelationFFTMetricImageFilter
   itkBlockMatchingNormalizedCrossCorrelationNeighborhoodIteratorMetricImageFilter
   itkSpectra1DSupportWindowImageFilter
-  itkCurvilinearArraySpecialCoordinatesImage
   itkFrequencyDomain1DFilterFunction
   itkFrequencyDomain1DImageFilter
   itkRegionFromReferenceImageFilter


### PR DESCRIPTION
### Overview

Fixes submodule wrapping to follow user-specified order of classes.

### Previous behavior

Classes were wrapped in alphabetical order despite an order being manually specified. This resulted in several warnings when loading the `Ultrasound` module in Python:

```
Loading Ultrasound... Warning: Unknown parameter 'itk::CurvilinearArraySpecialCoordinatesImage<float,2>' in template 'itk::BModeImageFilter'
Warning: Unknown parameter 'itk::CurvilinearArraySpecialCoordinatesImage<std::complex<float>,2>' in template 'itk::BModeImageFilter'
Warning: Unknown parameter 'itk::Image<std::list<itk::Index<2>>,2>' in template 'itk::Spectra1DSupportWindowToMaskImageFilter'
Warning: Unknown parameter 'itk::Image<std::list<itk::Index<3>>,3>' in template 'itk::Spectra1DSupportWindowToMaskImageFilter'
Warning: Unknown parameter 'itk::Image<std::list<itk::Index<2>>,2>' in template 'itk::Spectra1DImageFilter'
Warning: Unknown parameter 'itk::Image<std::list<itk::Index<3>>,3>' in template 'itk::Spectra1DImageFilter'
```

### New behavior

Setting `WRAPPER_SUBMODULE_ORDER` results in classes being wrapped in the user-specified order. I found this variable by tracing through ITK CMake code. Perhaps the variable name changed in ITK proper at some point?

`itkCurvilinearArraySpecialCoordinatesImage` is wrapped first because it conceptually makes sense to wrap a new image class before wrapping image filters that may consume that class.

Warnings for `BModeImageFilter` relating to `CurvilinearArraySpecialCoordinatesImage` are resolved. Warnings for Spectra1D classes still remain and need to be investigated.
