### PR TITLE
BUG: Fix `itk::AttenuationImageFilter` region threading

### DIFF
--- a/include/itkAttenuationImageFilter.h
+++ b/include/itkAttenuationImageFilter.h
@@ -205,7 +205,7 @@ protected:
   BeforeThreadedGenerateData() override;
 
   void
-  DynamicThreadedGenerateData(const OutputRegionType &) override;
+  ThreadedGenerateData(const OutputRegionType & regionForThread, ThreadIdType) override;
 
   const ImageRegionSplitterBase *
   GetImageRegionSplitter() const override;

--- a/include/itkAttenuationImageFilter.hxx
+++ b/include/itkAttenuationImageFilter.hxx
@@ -33,7 +33,7 @@ template <typename TInputImage, typename TOutputImage, typename TMaskImage>
 AttenuationImageFilter<TInputImage, TOutputImage, TMaskImage>::AttenuationImageFilter()
 {
   this->SetNumberOfRequiredInputs(1);
-  this->DynamicMultiThreadingOn();
+  this->DynamicMultiThreadingOff();
 }
 
 template <typename TInputImage, typename TOutputImage, typename TMaskImage>
@@ -126,8 +126,9 @@ AttenuationImageFilter<TInputImage, TOutputImage, TMaskImage>::BeforeThreadedGen
 
 template <typename TInputImage, typename TOutputImage, typename TMaskImage>
 void
-AttenuationImageFilter<TInputImage, TOutputImage, TMaskImage>::DynamicThreadedGenerateData(
-  const OutputRegionType & regionForThread)
+AttenuationImageFilter<TInputImage, TOutputImage, TMaskImage>::ThreadedGenerateData(
+  const OutputRegionType & regionForThread,
+  ThreadIdType)
 {
   if (regionForThread.GetNumberOfPixels() == 0)
   {


### PR DESCRIPTION
Disables dynamic threading to enforce same-size regions and correctly
use the image region splitter to enforce continuity along scan lines.

Closes #185.