### PR TITLE
BUG: `Spectra1DAveragingImageFilter` iterator fix

### DIFF
--- a/include/itkSpectra1DAveragingImageFilter.hxx
+++ b/include/itkSpectra1DAveragingImageFilter.hxx
@@ -188,6 +188,7 @@ Spectra1DAveragingImageFilter<TInputImage, TOutputImage>::GenerateData()
         }
 
         progress.CompletedPixel();
+        iIt.NextLine();
       }
     }
   }


### PR DESCRIPTION
Resolves an issue where `Spectra1DAveragingImageFilter` was observed to hang in Python testing due to not advancing to the next line.

This was probably not caught in testing due to input data being a one-pixel image, so there was never a "second line" to step through.