### PR TITLE
BUG: Make ITKTestKernel a test dependency

### DIFF
--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -23,10 +23,10 @@ itk_module(Ultrasound
     Strain
   PRIVATE_DEPENDS
     ITKHDF5
-    ITKTestKernel
     ITKImageSources
     ITKEigen3
   TEST_DEPENDS
+    ITKTestKernel
     ITKVideoCore
     ITKVideoIO
   EXCLUDE_FROM_DEFAULT


### PR DESCRIPTION
When ITK is compiled with the ITKUltrasound remote module with testing
enabled (e.g. -DModule_Ultrasound=ON -DBUILD_TESTING=ON) the Ultrasound
test driver previously failed to find the itkTestingMacros.h header.

With this change ITKTestKernel is now a test dependency so that the test
driver can be built appropriately when "test/" is not built as a
subdirectory of the root Ultrasound directory.