### PR TITLE
Support build against itk5.3

### DIFF
--- a/include/itkBlockMatchingBlockAffineTransformMetricImageFilter.h
+++ b/include/itkBlockMatchingBlockAffineTransformMetricImageFilter.h
@@ -79,7 +79,7 @@ public:
 
   /** Type of the strain image. */
   using StrainImageType = Image<SymmetricSecondRankTensor<TStrainValueType, ImageDimension>, ImageDimension>;
-  using StrainImagePointerType = typename StrainImageType::Pointer;
+  using StrainImagePointerType = typename StrainImageType::ConstPointer;
   using StrainInterpolatorType = LinearInterpolateImageFunction<StrainImageType, double>;
 
   /** Type of the transform. */
@@ -101,7 +101,7 @@ public:
   itkGetConstObjectMacro(MetricImageFilter, Superclass);
 
   /** Set/Get the strain image used to modify the fixed image block. */
-  itkSetObjectMacro(StrainImage, StrainImageType);
+  itkSetConstObjectMacro(StrainImage, StrainImageType);
   itkGetConstObjectMacro(StrainImage, StrainImageType);
 
 protected:

--- a/include/itkBlockMatchingDisplacementPipeline.hxx
+++ b/include/itkBlockMatchingDisplacementPipeline.hxx
@@ -32,8 +32,8 @@ template <typename TFixedPixel,
 DisplacementPipeline<TFixedPixel, TMovingPixel, TMetricPixel, TCoordRep, VImageDimension>::DisplacementPipeline()
   : m_LevelRegistrationMethodTextProgressBar(false)
   , m_Direction(0)
-  , m_MaximumAbsStrainAllowed(0.075)
   , m_BlockOverlap(0.75)
+  , m_MaximumAbsStrainAllowed(0.075)
   , m_ScaleBlockByStrain(true)
   , m_RegularizationMaximumNumberOfIterations(2)
 {

--- a/include/itkBlockMatchingMetricImageToDisplacementCalculator.h
+++ b/include/itkBlockMatchingMetricImageToDisplacementCalculator.h
@@ -137,13 +137,13 @@ public:
   /** Modify the associated BlockMatching::ImageRegistrationMethod's
    * GenerateInputRequestedRegion().  */
   virtual void
-  ModifyGenerateInputRequestedRegion(RegionType & region)
+  ModifyGenerateInputRequestedRegion(RegionType & itkNotUsed(region))
   {}
 
   /** Modify the associated BlockMatching::ImageRegistrationMethod's
    * EnlargeOutputRequestedRegion().  */
   virtual void
-  ModifyEnlargeOutputRequestedRegion(DataObject * data)
+  ModifyEnlargeOutputRequestedRegion(DataObject * itkNotUsed(data))
   {}
 
 protected:

--- a/include/itkBlockMatchingMultiResolutionImageRegistrationMethod.h
+++ b/include/itkBlockMatchingMultiResolutionImageRegistrationMethod.h
@@ -191,7 +191,7 @@ protected:
 
   /** Generates the entire displacement image. */
   void
-  EnlargeOutputRequestedRegion(DataObject * data) override
+  EnlargeOutputRequestedRegion(DataObject * itkNotUsed(data)) override
   {
     TDisplacementImage * output = this->GetOutput(0);
     output->SetRequestedRegionToLargestPossibleRegion();

--- a/include/itkBlockMatchingMultiResolutionIterationCommand.hxx
+++ b/include/itkBlockMatchingMultiResolutionIterationCommand.hxx
@@ -26,7 +26,7 @@ namespace BlockMatching
 
 template <typename TMultiResolutionMethod>
 void
-MultiResolutionIterationCommand<TMultiResolutionMethod>::Execute(const Object * object, const EventObject & event)
+MultiResolutionIterationCommand<TMultiResolutionMethod>::Execute(const Object * itkNotUsed(object), const EventObject & event)
 {
   if (!(IterationEvent().CheckEvent(&event)))
   {

--- a/include/itkBlockMatchingMultiResolutionIterationObserver.h
+++ b/include/itkBlockMatchingMultiResolutionIterationObserver.h
@@ -51,6 +51,7 @@ public:
 
   itkNewMacro(Self);
 
+  using Superclass::Execute;
   void
   Execute(itk::Object * caller, const itk::EventObject & event) override;
   //{

--- a/include/itkBlockMatchingNormalizedCrossCorrelationMetricImageFilter.h
+++ b/include/itkBlockMatchingNormalizedCrossCorrelationMetricImageFilter.h
@@ -90,7 +90,7 @@ protected:
 
   /** Don't let the default mess with our output requested regions. */
   virtual void
-  GenerateOutputRequestedRegion(DataObject * data) override{};
+  GenerateOutputRequestedRegion(DataObject * itkNotUsed(data)) override{};
 
   /** Generates helper images for the calculation.  These are only needed for
    * internal calculation, but they are put on the

--- a/include/itkBlockMatchingNormalizedCrossCorrelationMetricImageFilter.hxx
+++ b/include/itkBlockMatchingNormalizedCrossCorrelationMetricImageFilter.hxx
@@ -139,7 +139,7 @@ NormalizedCrossCorrelationMetricImageFilter<TFixedImage, TMovingImage, TMetricIm
 template <typename TFixedImage, typename TMovingImage, typename TMetricImage>
 void
 NormalizedCrossCorrelationMetricImageFilter<TFixedImage, TMovingImage, TMetricImage>::EnlargeOutputRequestedRegion(
-  DataObject * data)
+  DataObject * itkNotUsed(data))
 {
   MetricImagePointerType outputPtr = this->GetOutput(0);
 

--- a/include/itkBlockMatchingOptimizingInterpolationDisplacementCalculator.hxx
+++ b/include/itkBlockMatchingOptimizingInterpolationDisplacementCalculator.hxx
@@ -92,7 +92,7 @@ OptimizingInterpolationDisplacementCalculator<TMetricImage, TDisplacementImage, 
     for (unsigned int i = 0; i < ImageDimension; i++)
       parameters[i] += 0.1;
     m_CostFunction->Initialize(parameters);
-    m_CostFunction->GetInterpolator()->SetInputImage(metricImage);
+    const_cast<InterpolatorType*>(m_CostFunction->GetInterpolator())->SetInputImage(metricImage);
     m_Optimizer->StartOptimization();
 
     parameters = m_Optimizer->GetCurrentPosition();

--- a/include/itkBlockMatchingStrainWindowBlockAffineTransformCommand.hxx
+++ b/include/itkBlockMatchingStrainWindowBlockAffineTransformCommand.hxx
@@ -70,13 +70,15 @@ StrainWindowBlockAffineTransformCommand<TStrainWindowDisplacemenCalculator,
 
   if (m_UseStrainWindowStrain)
   {
-    m_BlockAffineTransformMetricImageFilter->SetStrainImage(strainWindower->GetStrainImageFilter()->GetOutput());
+    m_BlockAffineTransformMetricImageFilter->SetStrainImage(
+          const_cast<typename BlockAffineTransformMetricImageFilterType::StrainImageType *>(strainWindower->GetStrainImageFilter()->GetOutput()));
   }
   else
   {
     m_StrainImageFilter->SetInput(strainWindower->GetStrainImageFilter()->GetInput());
     m_StrainImageFilter->Update();
-    m_BlockAffineTransformMetricImageFilter->SetStrainImage(m_StrainImageFilter->GetOutput());
+    m_BlockAffineTransformMetricImageFilter->SetStrainImage(
+          const_cast<typename BlockAffineTransformMetricImageFilterType::StrainImageType *>(m_StrainImageFilter->GetOutput()));
   }
 }
 

--- a/include/itkBlockMatchingStrainWindowBlockAffineTransformCommand.hxx
+++ b/include/itkBlockMatchingStrainWindowBlockAffineTransformCommand.hxx
@@ -70,15 +70,13 @@ StrainWindowBlockAffineTransformCommand<TStrainWindowDisplacemenCalculator,
 
   if (m_UseStrainWindowStrain)
   {
-    m_BlockAffineTransformMetricImageFilter->SetStrainImage(
-          const_cast<typename BlockAffineTransformMetricImageFilterType::StrainImageType *>(strainWindower->GetStrainImageFilter()->GetOutput()));
+    m_BlockAffineTransformMetricImageFilter->SetStrainImage(strainWindower->GetStrainImageFilter()->GetOutput());
   }
   else
   {
     m_StrainImageFilter->SetInput(strainWindower->GetStrainImageFilter()->GetInput());
     m_StrainImageFilter->Update();
-    m_BlockAffineTransformMetricImageFilter->SetStrainImage(
-          const_cast<typename BlockAffineTransformMetricImageFilterType::StrainImageType *>(m_StrainImageFilter->GetOutput()));
+    m_BlockAffineTransformMetricImageFilter->SetStrainImage(m_StrainImageFilter->GetOutput());
   }
 }
 

--- a/include/itkLinearLeastSquaresGradientImageFilter.hxx
+++ b/include/itkLinearLeastSquaresGradientImageFilter.hxx
@@ -22,7 +22,7 @@
 #include "itkConstNeighborhoodIterator.h"
 #include "itkImageRegionIterator.h"
 
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 #include "vnl/algo/vnl_svd.h"
 
 namespace itk
@@ -94,7 +94,7 @@ LinearLeastSquaresGradientImageFilter<TInputImage, TOperatorValueType, TOutputVa
 {
   unsigned int maxConsistentCount = 1;
   unsigned int currentConsistentCount = maxConsistentCount;
-  int          previousSgn = vnl_math_sgn0(nit.GetPixel(s.start()));
+  int          previousSgn = itk::Math::sgn0(nit.GetPixel(s.start()));
   int          nextSgn;
   unsigned int maxConsistentIdx = 0;
   unsigned int currentConsistentIdx = maxConsistentIdx;
@@ -102,7 +102,7 @@ LinearLeastSquaresGradientImageFilter<TInputImage, TOperatorValueType, TOutputVa
   unsigned int nitIdx;
   for (sliceIdx = 1, nitIdx = s.start() + s.stride(); sliceIdx < s.size(); ++sliceIdx, nitIdx += s.stride())
   {
-    nextSgn = vnl_math_sgn0(nit.GetPixel(nitIdx));
+    nextSgn = itk::Math::sgn0(nit.GetPixel(nitIdx));
     if (nextSgn == previousSgn)
     {
       ++currentConsistentCount;


### PR DESCRIPTION
Remaining error reported when building SlicerITKUltrasound (based of https://github.com/KitwareMedical/SlicerITKUltrasound/pull/78) are like the following:

```
In file included from /home/jcfr/Projects/SlicerITKUltrasound-Release/ITKUltrasound/include/itkBlockMatchingStrainWindowBlockAffineTransformCommand.h:105,
                 from /home/jcfr/Projects/SlicerITKUltrasound/GenerateDisplacementFromTimeSeries/GenerateDisplacementFromTimeSeries.cxx:38:
/home/jcfr/Projects/SlicerITKUltrasound-Release/ITKUltrasound/include/itkBlockMatchingStrainWindowBlockAffineTransformCommand.hxx: In instantiation of ‘void itk::BlockMatching::StrainWindowBlockAffineTransformCommand<TStrainWindowDisplacemenCalculator, TBlockAffineTransformMetricImageFilter, TStrainImageFilter>::Execute(const itk::Object*, const itk::EventObject&) [with TStrainWindowDisplacemenCalculator = itk::BlockMatching::StrainWindowDisplacementCalculator<itk::Image<float, 2>, itk::Image<itk::Vector<float, 2>, 2>, float>; TBlockAffineTransformMetricImageFilter = itk::BlockMatching::BlockAffineTransformMetricImageFilter<itk::Image<unsigned char, 2>, itk::Image<unsigned char, 2>, itk::Image<float, 2>, float>; TStrainImageFilter = itk::StrainImageFilter<itk::Image<itk::Vector<float, 2>, 2>, float, float>]’:
/home/jcfr/Projects/SlicerITKUltrasound-Release/ITKUltrasound/include/itkBlockMatchingStrainWindowBlockAffineTransformCommand.hxx:49:1:   required from here
/home/jcfr/Projects/SlicerITKUltrasound-Release/ITKUltrasound/include/itkBlockMatchingStrainWindowBlockAffineTransformCommand.hxx:73:5: error: invalid conversion from ‘const OutputImageType*’ {aka ‘const itk::Image<itk::SymmetricSecondRankTensor<float, 2>, 2>*’} to ‘itk::BlockMatching::BlockAffineTransformMetricImageFilter<itk::Image<unsigned char, 2>, itk::Image<unsigned char, 2>, itk::Image<float, 2>, float>::StrainImageType*’ {aka ‘itk::Image<itk::SymmetricSecondRankTensor<float, 2>, 2>*’} [-fpermissive]
   73 |     m_BlockAffineTransformMetricImageFilter->SetStrainImage(strainWindower->GetStrainImageFilter()->GetOutput());
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     |
      |     const OutputImageType* {aka const itk::Image<itk::SymmetricSecondRankTensor<float, 2>, 2>*}
In file included from /home/jcfr/Projects/Slicer-Release/ITK/Modules/IO/ImageBase/include/itkImageFileReaderException.h:22,
                 from /home/jcfr/Projects/Slicer-Release/ITK/Modules/IO/ImageBase/include/itkImageFileReader.h:20,
                 from /home/jcfr/Projects/SlicerITKUltrasound/GenerateDisplacementFromTimeSeries/GenerateDisplacementFromTimeSeries.cxx:19:
/home/jcfr/Projects/Slicer-Release/ITK/Modules/Core/Common/include/itkMacro.h:1097:33: note:   initializing argument 1 of ‘void itk::BlockMatching::BlockAffineTransformMetricImageFilter<TFixedImage, TMovingImage, TMetricImage, TStrainValueType>::SetStrainImage(itk::BlockMatching::BlockAffineTransformMetricImageFilter<TFixedImage, TMovingImage, TMetricImage, TStrainValueType>::StrainImageType*) [with TFixedImage = itk::Image<unsigned char, 2>; TMovingImage = itk::Image<unsigned char, 2>; TMetricImage = itk::Image<float, 2>; TStrainValueType = float; itk::BlockMatching::BlockAffineTransformMetricImageFilter<TFixedImage, TMovingImage, TMetricImage, TStrainValueType>::StrainImageType = itk::Image<itk::SymmetricSecondRankTensor<float, 2>, 2>]’
 1097 |   virtual void Set##name(type * _arg)                  \
/home/jcfr/Projects/SlicerITKUltrasound-Release/ITKUltrasound/include/itkBlockMatchingBlockAffineTransformMetricImageFilter.h:104:3: note: in expansion of macro ‘itkSetObjectMacro’
  104 |   itkSetObjectMacro(StrainImage, StrainImageType);
      |   ^~~~~~~~~~~~~~~~~
```

```
In file included from /home/jcfr/Projects/SlicerITKUltrasound-Release/ITKUltrasound/include/itkBlockMatchingStrainWindowBlockAffineTransformCommand.h:105,
                 from /home/jcfr/Projects/SlicerITKUltrasound-Release/ITKUltrasound/include/itkBlockMatchingDisplacementPipeline.h:42,
                 from /home/jcfr/Projects/SlicerITKUltrasound/GenerateDisplacementFromFrames/GenerateDisplacementFromFrames.cxx:25:
/home/jcfr/Projects/SlicerITKUltrasound-Release/ITKUltrasound/include/itkBlockMatchingStrainWindowBlockAffineTransformCommand.hxx: In instantiation of ‘void itk::BlockMatching::StrainWindowBlockAffineTransformCommand<TStrainWindowDisplacemenCalculator, TBlockAffineTransformMetricImageFilter, TStrainImageFilter>::Execute(const itk::Object*, const itk::EventObject&) [with TStrainWindowDisplacemenCalculator = itk::BlockMatching::StrainWindowDisplacementCalculator<itk::Image<float, 2>, itk::Image<itk::Vector<float, 2>, 2>, float>; TBlockAffineTransformMetricImageFilter = itk::BlockMatching::BlockAffineTransformMetricImageFilter<itk::Image<float, 2>, itk::Image<float, 2>, itk::Image<float, 2>, float>; TStrainImageFilter = itk::StrainImageFilter<itk::Image<itk::Vector<float, 2>, 2>, float, float>]’:
/home/jcfr/Projects/SlicerITKUltrasound-Release/ITKUltrasound/include/itkBlockMatchingStrainWindowBlockAffineTransformCommand.hxx:49:1:   required from here
/home/jcfr/Projects/SlicerITKUltrasound-Release/ITKUltrasound/include/itkBlockMatchingStrainWindowBlockAffineTransformCommand.hxx:73:5: error: invalid conversion from ‘const OutputImageType*’ {aka ‘const itk::Image<itk::SymmetricSecondRankTensor<float, 2>, 2>*’} to ‘itk::BlockMatching::BlockAffineTransformMetricImageFilter<itk::Image<float, 2>, itk::Image<float, 2>, itk::Image<float, 2>, float>::StrainImageType*’ {aka ‘itk::Image<itk::SymmetricSecondRankTensor<float, 2>, 2>*’} [-fpermissive]
   73 |     m_BlockAffineTransformMetricImageFilter->SetStrainImage(strainWindower->GetStrainImageFilter()->GetOutput());
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     |
      |     const OutputImageType* {aka const itk::Image<itk::SymmetricSecondRankTensor<float, 2>, 2>*}
In file included from /home/jcfr/Projects/Slicer-Release/ITK/Modules/IO/ImageBase/include/itkImageFileReaderException.h:22,
                 from /home/jcfr/Projects/Slicer-Release/ITK/Modules/IO/ImageBase/include/itkImageFileReader.h:20,
                 from /home/jcfr/Projects/SlicerITKUltrasound/GenerateDisplacementFromFrames/GenerateDisplacementFromFrames.cxx:19:
/home/jcfr/Projects/Slicer-Release/ITK/Modules/Core/Common/include/itkMacro.h:1097:33: note:   initializing argument 1 of ‘void itk::BlockMatching::BlockAffineTransformMetricImageFilter<TFixedImage, TMovingImage, TMetricImage, TStrainValueType>::SetStrainImage(itk::BlockMatching::BlockAffineTransformMetricImageFilter<TFixedImage, TMovingImage, TMetricImage, TStrainValueType>::StrainImageType*) [with TFixedImage = itk::Image<float, 2>; TMovingImage = itk::Image<float, 2>; TMetricImage = itk::Image<float, 2>; TStrainValueType = float; itk::BlockMatching::BlockAffineTransformMetricImageFilter<TFixedImage, TMovingImage, TMetricImage, TStrainValueType>::StrainImageType = itk::Image<itk::SymmetricSecondRankTensor<float, 2>, 2>]’
 1097 |   virtual void Set##name(type * _arg)                  \
/home/jcfr/Projects/SlicerITKUltrasound-Release/ITKUltrasound/include/itkBlockMatchingBlockAffineTransformMetricImageFilter.h:104:3: note: in expansion of macro ‘itkSetObjectMacro’
  104 |   itkSetObjectMacro(StrainImage, StrainImageType);
      |   ^~~~~~~~~~~~~~~~~
```

```
In file included from /home/jcfr/Projects/SlicerITKUltrasound-Release/ITKUltrasound/include/itkBlockMatchingOptimizingInterpolationDisplacementCalculator.h:202,
                 from /home/jcfr/Projects/SlicerITKUltrasound-Release/ITKUltrasound/include/itkBlockMatchingDisplacementPipeline.h:39,
                 from /home/jcfr/Projects/SlicerITKUltrasound/GenerateDisplacementFromFrames/GenerateDisplacementFromFrames.cxx:25:
/home/jcfr/Projects/SlicerITKUltrasound-Release/ITKUltrasound/include/itkBlockMatchingOptimizingInterpolationDisplacementCalculator.hxx: In instantiation of ‘void itk::BlockMatching::OptimizingInterpolationDisplacementCalculator<TMetricImage, TDisplacementImage, TCoordRep>::SetMetricImagePixel(const PointType&, const IndexType&, itk::BlockMatching::OptimizingInterpolationDisplacementCalculator<TMetricImage, TDisplacementImage, TCoordRep>::MetricImageType*) [with TMetricImage = itk::Image<float, 2>; TDisplacementImage = itk::Image<itk::Vector<float, 2>, 2>; TCoordRep = double; itk::BlockMatching::OptimizingInterpolationDisplacementCalculator<TMetricImage, TDisplacementImage, TCoordRep>::PointType = itk::Point<double, 2>; itk::BlockMatching::OptimizingInterpolationDisplacementCalculator<TMetricImage, TDisplacementImage, TCoordRep>::IndexType = itk::Index<2>; itk::BlockMatching::OptimizingInterpolationDisplacementCalculator<TMetricImage, TDisplacementImage, TCoordRep>::MetricImageType = itk::Image<float, 2>]’:
/home/jcfr/Projects/SlicerITKUltrasound-Release/ITKUltrasound/include/itkBlockMatchingOptimizingInterpolationDisplacementCalculator.hxx:41:1:   required from here
/home/jcfr/Projects/SlicerITKUltrasound-Release/ITKUltrasound/include/itkBlockMatchingOptimizingInterpolationDisplacementCalculator.hxx:95:5: error: passing ‘const InterpolatorType’ {aka ‘const itk::InterpolateImageFunction<itk::Image<float, 2>, double>’} as ‘this’ argument discards qualifiers [-fpermissive]
   95 |     m_CostFunction->GetInterpolator()->SetInputImage(metricImage);
      |     ^~~~~~~~~~~~~~
In file included from /home/jcfr/Projects/Slicer-Release/ITK/Modules/Core/ImageFunction/include/itkImageFunction.h:229,
                 from /home/jcfr/Projects/Slicer-Release/ITK/Modules/Core/ImageFunction/include/itkInterpolateImageFunction.h:21,
                 from /home/jcfr/Projects/Slicer-Release/ITK/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.h:23,
                 from /home/jcfr/Projects/SlicerITKUltrasound-Release/ITKUltrasound/include/itkBlockMatchingDisplacementPipeline.h:26,
                 from /home/jcfr/Projects/SlicerITKUltrasound/GenerateDisplacementFromFrames/GenerateDisplacementFromFrames.cxx:25:
/home/jcfr/Projects/Slicer-Release/ITK/Modules/Core/ImageFunction/include/itkImageFunction.hxx:57:1: note:   in call to ‘void itk::ImageFunction<TInputImage, TOutput, TCoordRep>::SetInputImage(const InputImageType*) [with TInputImage = itk::Image<float, 2>; TOutput = double; TCoordRep = double; itk::ImageFunction<TInputImage, TOutput, TCoordRep>::InputImageType = itk::Image<float, 2>]’
   57 | ImageFunction<TInputImage, TOutput, TCoordRep>::SetInputImage(const InputImageType * ptr)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```

cc: @dzenanz @thewtex 