### PR TITLE
ENH: Bump to 0.5.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from skbuild import setup
 
 setup(
     name='itk-ultrasound',
-    version='0.5.3',
+    version='0.5.4',
     author='Matthew McCormick',
     author_email='matt.mccormick@kitware.com',
     packages=['itk'],


### PR DESCRIPTION
Bumps ITKUltrasound package to 0.5.4 for tag and distribution on PyPI. Will address #177 where notebooks are failing because they rely on factory mechanisms partially broken in 0.5.3.

See [https://github.com/KitwareMedical/ITKUltrasound/commits/master(https://github.com/KitwareMedical/ITKUltrasound/commits/master) for changes since 0.5.3 tag on April 14th.