### PR TITLE
ENH: Remove PR notebook checks

### DIFF
--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -1,6 +1,9 @@
 name: Test notebooks
 
-on: [push,pull_request]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   nbmake:


### PR DESCRIPTION
Notebook checks always run with the most recent `itk-ultrasound` PyPI
package release and do not reflect individual PR changes. This updates
the notebook workflow to only run on commits in the `master` branch to
reduce confusion.

Addresses #177. Reference discussion at
https://github.community/t/trigger-workflow-only-on-pull-request-merge/17359 .