### PR TITLE
ENH: Bump ITK to v5.3rc04.post2

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -3,13 +3,13 @@ name: Build, test, package
 on: [push,pull_request]
 
 env:
-  itk-git-tag: "v5.3rc04"
-  itk-wheel-tag: "v5.3rc04.post1"
-  ITKMeshToPolyData-git-tag: v0.8.3
-  ITKBSplineGradient-git-tag: v0.2.7
-  ITKHigherOrderAccurateGradient-git-tag: v1.1.3
-  ITKSplitComponents-git-tag: v2.0.7
-  ITKStrain-git-tag: v0.3.7
+  itk-git-tag: "835dc01388d22c4b4c9a46b01dbdfe394ec23511"
+  itk-wheel-tag: "v5.3rc04.post2"
+  ITKMeshToPolyData-git-tag: v0.8.4
+  ITKBSplineGradient-git-tag: v0.2.8
+  ITKHigherOrderAccurateGradient-git-tag: v1.1.4
+  ITKSplitComponents-git-tag: v2.0.8
+  ITKStrain-git-tag: v0.3.8
 
 jobs:
   build-test-cxx:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from skbuild import setup
 
 setup(
     name='itk-ultrasound',
-    version='0.5.6',
+    version='0.5.7',
     author='Matthew McCormick',
     author_email='matt.mccormick@kitware.com',
     packages=['itk'],
@@ -41,11 +41,11 @@ setup(
     keywords='ITK InsightToolkit ultrasound imaging',
     url=r'https://www.insight-journal.org/browse/publication/722',
     install_requires=[
-        r'itk>=5.3rc04.post1',
-        r'itk-meshtopolydata>=0.8.3'
-        r'itk-bsplinegradient>=0.2.7',
-        r'itk-higherorderaccurategradient>=1.1.3',
-        r'itk-splitcomponents>=2.0.7',
-        r'itk-strain>=0.3.7',
+        r'itk>=5.3rc04.post2',
+        r'itk-meshtopolydata>=0.8.4'
+        r'itk-bsplinegradient>=0.2.8',
+        r'itk-higherorderaccurategradient>=1.1.4',
+        r'itk-splitcomponents>=2.0.8',
+        r'itk-strain>=0.3.8',
     ]
     )


### PR DESCRIPTION
Depends on [https://github.com/InsightSoftwareConsortium/ITKHigherOrderAccurateGradient/pull/41](https://github.com/InsightSoftwareConsortium/ITKHigherOrderAccurateGradient/pull/41) and [https://github.com/InsightSoftwareConsortium/ITKMeshToPolyData/pull/50](https://github.com/InsightSoftwareConsortium/ITKMeshToPolyData/pull/50)