### PR TITLE
STYLE: Reorganize wrapping files to ease PA3DSCI migration to ITK core

### DIFF
--- a/wrapping/itkCurvilinearArraySpecialCoordinatesImage.wrap
+++ b/wrapping/itkCurvilinearArraySpecialCoordinatesImage.wrap
@@ -1,18 +1,4 @@
-itk_wrap_include("list")
 itk_wrap_include("complex")
-
-# Wrap underlying class hierarchy
-itk_wrap_class("itk::SpecialCoordinatesImage" POINTER)
-  foreach(d ${ITK_WRAP_IMAGE_DIMS})
-    foreach(t ${WRAP_ITK_SCALAR})
-      itk_wrap_template("${ITKM_${t}}${d}" "${ITKT_${t}}, ${d}")
-    endforeach()
-    foreach(t3 ${WRAP_ITK_COMPLEX_REAL})
-      itk_wrap_template("${ITKM_${t3}}${d}" "${ITKT_${t3}}, ${d}")
-    endforeach()
-  endforeach()
-itk_end_wrap_class()
-
 
 # Explicitly override template method wrappings so that implicit
 # scalar type is always `double` for greatest precision.

--- a/wrapping/itkCurvilinearArraySpecialCoordinatesImageFilters.wrap
+++ b/wrapping/itkCurvilinearArraySpecialCoordinatesImageFilters.wrap
@@ -93,16 +93,6 @@ itk_wrap_class("itk::RescaleIntensityImageFilter" POINTER_WITH_2_SUPERCLASSES)
   endforeach()
 itk_end_wrap_class()
 
-itk_wrap_include("itkSpectra1DSupportWindowToMaskImageFilter.h")
-itk_wrap_class("itk::Spectra1DSupportWindowToMaskImageFilter" POINTER_WITH_2_SUPERCLASSES)
-  foreach(d ${ITK_WRAP_IMAGE_DIMS})
-    foreach(t ${WRAP_ITK_INT})
-      itk_wrap_template("IlistitkIndex${d}${d}CASCI${ITKM_${t}}${d}"
-        "itk::Image< std::list< itk::Index< ${d} > >, ${d} >, itk::CurvilinearArraySpecialCoordinatesImage< ${ITKT_${t}}, ${d} >")
-    endforeach()
-  endforeach()
-itk_end_wrap_class()
-
 # The rest is needed for ResampleImageFilter and interpolator functions
 set(resample_filter_dimensions 2 3)
 set(resample_filter_pixel_types "F")

--- a/wrapping/itkImageUltrasound.wrap
+++ b/wrapping/itkImageUltrasound.wrap
@@ -4,6 +4,7 @@
 
 itk_wrap_include("list")
 itk_wrap_include("itkIndex.h")
+
 set(TEMPLATE_LIST_INDEX "")
 foreach(d ${ITK_WRAP_IMAGE_DIMS})
   set(TEMPLATE_LIST_INDEX "${TEMPLATE_LIST_INDEX}

--- a/wrapping/itkSpectra1DSupportWindowToMaskImageFilter.wrap
+++ b/wrapping/itkSpectra1DSupportWindowToMaskImageFilter.wrap
@@ -1,6 +1,8 @@
 itk_wrap_include("list")
 itk_wrap_include("itkIndex.h")
 itk_wrap_include("itkImage.h")
+itk_wrap_include("itkPhasedArray3DSpecialCoordinatesImage.h")
+itk_wrap_include("itkCurvilinearArraySpecialCoordinatesImage.h")
 
 itk_wrap_class("itk::Spectra1DSupportWindowToMaskImageFilter" POINTER_WITH_2_SUPERCLASSES)
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
@@ -8,4 +10,14 @@ itk_wrap_class("itk::Spectra1DSupportWindowToMaskImageFilter" POINTER_WITH_2_SUP
       itk_wrap_template("IlistitkIndex${d}${d}${ITKM_I${t}${d}}" "itk::Image< std::list< itk::Index< ${d} > >, ${d} >, ${ITKT_I${t}${d}}")
     endforeach(t)
   endforeach(d)
+  foreach(t ${WRAP_ITK_INT})
+    itk_wrap_template("IlistitkIndex33PA3DSCI${ITKM_${t}}"
+      "itk::Image< std::list< itk::Index< 3 > >, 3 >, itk::PhasedArray3DSpecialCoordinatesImage< ${ITKT_${t}} >")
+  endforeach()
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(t ${WRAP_ITK_INT})
+      itk_wrap_template("IlistitkIndex${d}${d}CASCI${ITKM_${t}}${d}"
+        "itk::Image< std::list< itk::Index< ${d} > >, ${d} >, itk::CurvilinearArraySpecialCoordinatesImage< ${ITKT_${t}}, ${d} >")
+    endforeach()
+  endforeach()
 itk_end_wrap_class()


### PR DESCRIPTION
This is a follow-up to #232.