### PR TITLE
COMP: Specify `cmake_minimum_required` prior to top-level `project` call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(Ultrasound)
 cmake_minimum_required(VERSION 3.16.3)
+project(Ultrasound)
 
 if(POLICY CMP0135)
   cmake_policy(SET CMP0135 NEW)


### PR DESCRIPTION
Specify `cmake_minimum_required` prior to top-level `project` call in `CMakeLists.txt`.

Fixes:
```
CMake Warning (dev) at CMakeLists.txt:1 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

raised for example in:
https://open.cdash.org/builds/10235866/configure